### PR TITLE
Allow to start a sprint at a certain time in the next hour

### DIFF
--- a/commands/writing/sprint.js
+++ b/commands/writing/sprint.js
@@ -36,6 +36,7 @@ module.exports = class SprintCommand extends Command {
             examples: [
                 '`sprint start` Quickstart a sprint with the default settings',
                 '`sprint for 20 in 3` Schedules a sprint for 20 minutes, to start in 3 minutes',
+                '`sprint for 20 at :30` Schedules a sprint for 20 minutes, starting the next time it is half past the current hour',
                 '`sprint cancel` Cancels the current sprint. This can only be done by the person who created the sprint, or any users with the MANAGE_MESSAGES permission',
                 '`sprint join` Joins the current sprint',
                 '`sprint join 100` Joins the current sprint, with a starting word count of 100',
@@ -114,6 +115,14 @@ module.exports = class SprintCommand extends Command {
         }
         
         else if (opt1 === 'for'){
+            if (opt3 == 'at'){
+                const startTime = parseInt(opt4.indexOf(':') !== -1 ? opt4.substr(1) : opt4, 10);
+                if (isNaN(startTime) || startTime === null || startTime === undefined || startTime >= 60) {
+                    return msg.say('Sorry, I can\'t understand that - the correct command looks like this: `sprint for 20 at :05`')
+                }
+                
+                opt4 = (60 + startTime - (new Date()).getMinutes()) % 60;
+            }
             if (opt3 === 'now'){
                 opt4 = 0;
             }

--- a/commands/writing/sprint.js
+++ b/commands/writing/sprint.js
@@ -36,7 +36,7 @@ module.exports = class SprintCommand extends Command {
             examples: [
                 '`sprint start` Quickstart a sprint with the default settings',
                 '`sprint for 20 in 3` Schedules a sprint for 20 minutes, to start in 3 minutes',
-                '`sprint for 20 at :30` Schedules a sprint for 20 minutes, starting the next time it is half past the current hour',
+                '`sprint for 20 at :30` Schedules a sprint for 20 minutes, starting the next time it is half past the current hour (UTC)',
                 '`sprint cancel` Cancels the current sprint. This can only be done by the person who created the sprint, or any users with the MANAGE_MESSAGES permission',
                 '`sprint join` Joins the current sprint',
                 '`sprint join 100` Joins the current sprint, with a starting word count of 100',


### PR DESCRIPTION
This should allow to add support to have a sprint start at an explicit time.

In our discord, we tend to ask for a sprint by asking something along the lines of

> Anyone wanna sprint at :30

I want to support that use-case with the bot, too. So in addition to the `sprint for 20 in 3` syntax, I've added `sprint for 20 at :30` (or `sprint for 20 at 30`) as a possible syntax for the command. The bot then does the necessary calculations to figure out the start-time in minutes, and uses existing code-paths.



